### PR TITLE
remove useless eslint config

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,55 +1,20 @@
 env:
   node: true
   browser: true
-  es6: true
-extends: ['eslint:recommended', 'plugin:react/recommended', 'airbnb']
+extends: 
+  - 'airbnb'
 parser: 'babel-eslint'
-parserOptions:
-  ecmaFeatures:
-    experimentalObjectRestSpread: true
-    jsx: true
-  sourceType: module
-plugins:
-  - react
 rules:
-  strict: 0
-  indent:
-    - error
-    - 2
-    - SwitchCase: 1
-      VariableDeclarator: 
-        var: 2
-        let: 2
-        const: 3
-  linebreak-style:
-    - error
-    - unix
-  quotes:
-    - error
-    - single
-  no-unused-vars:
-    - error
-    - args: after-used
-      vars: local
-  no-console:
-    - error
-  semi:
-    - error
-
-  # rules for jsx
-  react/jsx-uses-vars:
-    - 2
-  react/jsx-indent: 
-    - 2
-    - 2
-  # these avoid React is defined but not used error, and is set in plugin:react/recommended
-  # react/jsx-uses-react: 2
-  # react/react-in-jsx-scope: 2
-
   react/jsx-filename-extension:
-    - 1
-    - extensions: [".js", ".jsx"]
+    - error
+    - extensions: 
+      - '.js'
+      - '.jsx'
 
+  # TODO: can be removed after airbnb publish there new version
   jsx-a11y/anchor-is-valid:
     - error
-    - specialLink: ["to"]
+    - components: 
+        - 'Link'
+      specialLink: 
+        - 'to'


### PR DESCRIPTION
follow up #20 , remove useless part since we already extend airbnb config

- es6 env setting maybe not necessary, try removing it
- remove redundant extends since we follow airbnb rules
- parserOptions are set in `eslint-config-airbnb-base` already
- plugins: ['react'] is set in `eslint-config-airbnb`
- remove redundant rules
- single quote
- TODO for jsx-a11y/anchor-is-valid rule
  